### PR TITLE
[propfuzz-macro] support multiple #[propfuzz] invocations on the same function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,38 +51,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,11 +73,6 @@ dependencies = [
 [[package]]
 name = "glob"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -181,7 +144,6 @@ dependencies = [
 name = "propfuzz-macro"
 version = "0.1.0"
 dependencies = [
- "darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,11 +289,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "syn"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,14 +394,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum ctor 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "39858aa5bac06462d4dd4b9164848eb81ffc4aa5c479746393598fd193afa227"
-"checksum darling 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
-"checksum darling_core 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
-"checksum darling_macro 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum fnv 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-"checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum itoa 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
@@ -469,7 +422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 "checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
-"checksum strsim 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 "checksum syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d5d96e8cbb005d6959f119f773bfaebb5684296108fb32600c00cde305b2cd"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"

--- a/propfuzz-macro/Cargo.toml
+++ b/propfuzz-macro/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-darling = "0.10.2"
 proc-macro2 = "1.0.18"
 quote = "1.0.7"
-syn = { version = "1.0.31", features = ["full"] }
+syn = { version = "1.0.31", features = ["extra-traits", "full"] }

--- a/propfuzz-macro/src/config.rs
+++ b/propfuzz-macro/src/config.rs
@@ -1,0 +1,126 @@
+// Copyright (c) The propfuzz Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Configuration for propfuzz macros.
+
+use crate::errors::{Error, ErrorList, Result};
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+use syn::{spanned::Spanned, Lit, Meta, MetaNameValue, NestedMeta};
+
+/// Configuration for a propfuzz target.
+#[derive(Debug, Default)]
+pub(crate) struct PropfuzzConfigBuilder {
+    cases: Option<u32>,
+    fork: Option<bool>,
+}
+
+impl PropfuzzConfigBuilder {
+    /// Adds arguments.
+    pub(crate) fn apply_args<'a>(
+        &mut self,
+        args: impl IntoIterator<Item = &'a NestedMeta>,
+        errors: &mut ErrorList,
+    ) {
+        for arg in args {
+            self.apply_arg(arg, errors)
+        }
+    }
+
+    fn apply_arg(&mut self, arg: &NestedMeta, errors: &mut ErrorList) {
+        match arg {
+            NestedMeta::Meta(meta) => {
+                if meta.path().is_ident("cases") {
+                    errors.combine_fn(|| {
+                        let cases = read_u32(meta)?;
+                        replace_if_empty(meta.span(), &mut self.cases, cases)
+                    });
+                } else if meta.path().is_ident("fork") {
+                    errors.combine_fn(|| {
+                        let fork = read_bool(meta)?;
+                        replace_if_empty(meta.span(), &mut self.fork, fork)
+                    });
+                } else {
+                    errors.combine(Error::new_spanned(meta.path(), "argument not recognized"));
+                }
+            }
+            NestedMeta::Lit(meta) => {
+                errors.combine(Error::new_spanned(meta, "expected key = value format"));
+            }
+        }
+    }
+
+    /// Completes building args and returns a `PropfuzzConfig`.
+    pub(crate) fn finish(self) -> PropfuzzConfig {
+        let cases = self.cases;
+        let fork = self.fork.unwrap_or(false);
+
+        PropfuzzConfig {
+            proptest: ProptestConfig { cases, fork },
+        }
+    }
+}
+
+/// Overall config for a single propfuzz function, fully built.
+#[derive(Debug)]
+pub(crate) struct PropfuzzConfig {
+    pub(crate) proptest: ProptestConfig,
+}
+
+/// Proptest config for a single propfuzz function.
+#[derive(Debug, Default)]
+pub(crate) struct ProptestConfig {
+    pub(crate) cases: Option<u32>,
+    pub(crate) fork: bool,
+}
+
+/// Generates a ProptestConfig for this function.
+impl ToTokens for ProptestConfig {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self { cases, fork } = self;
+
+        tokens.extend(quote! {
+            let mut config = ::propfuzz::test::test_runner::Config::default();
+            config.fork = #fork;
+            config.source_file = Some(file!());
+        });
+
+        if let Some(cases) = cases {
+            tokens.extend(quote! {
+                config.cases = #cases;
+            });
+        }
+        tokens.extend(quote! { config })
+    }
+}
+
+fn read_bool(meta: &Meta) -> Result<bool> {
+    let name_value = name_value(meta)?;
+    match &name_value.lit {
+        Lit::Bool(lit) => Ok(lit.value),
+        _ => Err(Error::new_spanned(&name_value.lit, "expected bool")),
+    }
+}
+
+fn read_u32(meta: &Meta) -> Result<u32> {
+    let name_value = name_value(meta)?;
+    match &name_value.lit {
+        Lit::Int(lit) => Ok(lit.base10_parse::<u32>()?),
+        _ => Err(Error::new_spanned(&name_value.lit, "expected integer")),
+    }
+}
+
+fn name_value(meta: &Meta) -> Result<&MetaNameValue> {
+    match meta {
+        Meta::NameValue(meta) => Ok(meta),
+        _ => Err(Error::new_spanned(meta, "expected key = value format")),
+    }
+}
+
+fn replace_if_empty<T>(span: Span, dest: &mut Option<T>, val: T) -> Result<()> {
+    if dest.replace(val).is_some() {
+        Err(Error::new(span, "key specified more than once"))
+    } else {
+        Ok(())
+    }
+}

--- a/propfuzz-macro/src/lib.rs
+++ b/propfuzz-macro/src/lib.rs
@@ -8,6 +8,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, AttributeArgs, ItemFn};
 
+mod config;
 mod errors;
 mod propfuzz_impl;
 

--- a/propfuzz/tests/basic.rs
+++ b/propfuzz/tests/basic.rs
@@ -112,3 +112,21 @@ fn propfuzz_failing() {
         "minimal test case"
     );
 }
+
+/// Test multiple #[propfuzz] annotations.
+#[propfuzz(cases = 1024)]
+#[propfuzz(fork = true)]
+fn multi(_: Vec<u8>) {}
+
+#[test]
+fn propfuzz_multi() {
+    assert_eq!(__PROPFUZZ__multi.name(), "basic::multi");
+    assert_eq!(
+        __PROPFUZZ__multi.description(),
+        "Test multiple #[propfuzz] annotations."
+    );
+
+    let config = __PROPFUZZ__multi.proptest_config();
+    assert_eq!(config.cases, 1024, "correct case count");
+    assert_eq!(config.fork, true, "correct fork setting");
+}

--- a/propfuzz/tests/compile-fail/bad-args.rs
+++ b/propfuzz/tests/compile-fail/bad-args.rs
@@ -1,0 +1,38 @@
+// Copyright (c) The propfuzz Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Propfuzz with bad arguments.
+
+use propfuzz::propfuzz;
+
+/// Arguments of the wrong type (note multiple errors).
+#[propfuzz(cases = true, fork = 1024)]
+fn wrong_type1(_: u8) {}
+
+/// Basic test for repeated arguments.
+#[propfuzz(cases = 1024, cases = 2048)]
+fn repeated1(_: Vec<u8>) {}
+
+// Test lack of description for repeated2 as well.
+
+#[propfuzz(cases = 1024)]
+#[propfuzz(cases = 2048)]
+fn repeated2(_: Vec<u8>) {}
+
+/// Unsupported attribute kinds.
+#[propfuzz]
+#[propfuzz(wat)]
+#[propfuzz = "wat"]
+fn unsupported_kinds(_: u8) {}
+
+/// Repeated arguments and strategies.
+#[propfuzz(cases = 256)]
+#[propfuzz(cases = 512)]
+fn repeated_strategy(
+    #[strategy(any::<u8>())]
+    #[strategy(any::<u8>())]
+    _: u8,
+) {
+}
+
+fn main() {}

--- a/propfuzz/tests/compile-fail/bad-args.stderr
+++ b/propfuzz/tests/compile-fail/bad-args.stderr
@@ -1,0 +1,53 @@
+error: expected integer
+ --> $DIR/bad-args.rs:9:20
+  |
+9 | #[propfuzz(cases = true, fork = 1024)]
+  |                    ^^^^
+
+error: expected bool
+ --> $DIR/bad-args.rs:9:33
+  |
+9 | #[propfuzz(cases = true, fork = 1024)]
+  |                                 ^^^^
+
+error: key specified more than once
+  --> $DIR/bad-args.rs:13:26
+   |
+13 | #[propfuzz(cases = 1024, cases = 2048)]
+   |                          ^^^^^
+
+error: #[propfuzz] requires a description as a doc comment
+  --> $DIR/bad-args.rs:20:1
+   |
+20 | fn repeated2(_: Vec<u8>) {}
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: key specified more than once
+  --> $DIR/bad-args.rs:19:12
+   |
+19 | #[propfuzz(cases = 2048)]
+   |            ^^^^^
+
+error: argument not recognized
+  --> $DIR/bad-args.rs:24:12
+   |
+24 | #[propfuzz(wat)]
+   |            ^^^
+
+error: expected parentheses: #[propfuzz(...)]
+  --> $DIR/bad-args.rs:25:12
+   |
+25 | #[propfuzz = "wat"]
+   |            ^
+
+error: key specified more than once
+  --> $DIR/bad-args.rs:30:12
+   |
+30 | #[propfuzz(cases = 512)]
+   |            ^^^^^
+
+error: an argument cannot have more than one strategy
+  --> $DIR/bad-args.rs:33:5
+   |
+33 |     #[strategy(any::<u8>())]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/propfuzz/tests/compile-fail/no-description.stderr
+++ b/propfuzz/tests/compile-fail/no-description.stderr
@@ -1,4 +1,4 @@
-error: #[propfuzz] requires either a doc comment or description = "..."
+error: #[propfuzz] requires a description as a doc comment
  --> $DIR/no-description.rs:9:1
   |
 9 | fn no_description(_: usize) {}


### PR DESCRIPTION
This is useful when there are lots of arguments to the macro and they are
easier to read when broken up across several lines.